### PR TITLE
Fix comment typo in lexer

### DIFF
--- a/c-lox/src/lexer.c
+++ b/c-lox/src/lexer.c
@@ -167,7 +167,7 @@ static token make_identifier(void) {
 }
 
 static token make_number(void) {
-    // Advance until we find a non digit
+    // Advance until we find a non-digit
     while (is_digit(peek_current_char())) {
         advance_lexer();
     }


### PR DESCRIPTION
## Summary
- fix typo in comment above `make_number`

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_683f574c1f5c832a8ca5c570728e562c